### PR TITLE
Easier tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "llm-chain"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "llm-chain-hnsw"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "async-trait",
  "hnsw_rs",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "llm-chain-llama"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1331,14 +1331,14 @@ dependencies = [
 
 [[package]]
 name = "llm-chain-llama-sys"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "bindgen",
 ]
 
 [[package]]
 name = "llm-chain-local"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "async-trait",
  "lazy_static",
@@ -1352,14 +1352,14 @@ dependencies = [
 
 [[package]]
 name = "llm-chain-macros"
-version = "0.1.0"
+version = "0.12.3"
 dependencies = [
  "syn 2.0.18",
 ]
 
 [[package]]
 name = "llm-chain-openai"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "llm-chain-qdrant"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "lazy_static",
+ "llm-chain-macros",
  "markdown",
  "mockall",
  "paste",
@@ -1341,6 +1342,13 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "llm-chain-macros"
+version = "0.1.0"
+dependencies = [
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,9 +2454,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -190,11 +190,11 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -231,6 +231,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
 
 [[package]]
 name = "block-buffer"
@@ -841,7 +847,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -1613,7 +1619,7 @@ version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2055,7 +2061,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2189,7 +2195,7 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2292,7 +2298,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -2329,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1291,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "derive_builder",
+ "erased-serde",
  "futures",
  "lazy_static",
  "llm-chain-macros",
@@ -1366,6 +1376,9 @@ dependencies = [
  "async-trait",
  "futures",
  "llm-chain",
+ "llm-chain-hnsw",
+ "llm-chain-macros",
+ "llm-chain-openai",
  "qdrant-client",
  "serde",
  "serde_yaml",
@@ -2398,6 +2411,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,7 +2648,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/crates/llm-chain-hnsw/Cargo.toml
+++ b/crates/llm-chain-hnsw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-chain-hnsw"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "For using hnsw with llm-chain"
 license = "MIT"
@@ -15,7 +15,7 @@ repository = "https://github.com/sobelio/llm-chain/"
 [dependencies]
 async-trait = "0.1.68"
 hnsw_rs = "0.1.19"
-llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
+llm-chain = { path = "../llm-chain", version = "0.12.3", default-features = false }
 serde = "1.0.164"
 serde_json = "1.0.99"
 thiserror = "1.0.40"

--- a/crates/llm-chain-hnsw/Cargo.toml
+++ b/crates/llm-chain-hnsw/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/sobelio/llm-chain/"
 async-trait = "0.1.68"
 hnsw_rs = "0.1.19"
 llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
-serde = "1.0.163"
+serde = "1.0.164"
 serde_json = "1.0.99"
 thiserror = "1.0.40"
 tokio = "1.28.2"

--- a/crates/llm-chain-hnsw/Cargo.toml
+++ b/crates/llm-chain-hnsw/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1.68"
 hnsw_rs = "0.1.19"
 llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
 serde = "1.0.163"
-serde_json = "1.0.96"
+serde_json = "1.0.99"
 thiserror = "1.0.40"
 tokio = "1.28.2"
 

--- a/crates/llm-chain-llama-sys/Cargo.toml
+++ b/crates/llm-chain-llama-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llm-chain-llama-sys"
 description = "A library with bindings based on bindgen for LLaMA.cpp"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 license = "MIT"
 keywords = ["llm", "langchain", "llama", "chain"]

--- a/crates/llm-chain-llama-sys/Cargo.toml
+++ b/crates/llm-chain-llama-sys/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.65"
+bindgen = "0.66"
 
 [features]
 cuda = []

--- a/crates/llm-chain-llama/Cargo.toml
+++ b/crates/llm-chain-llama/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.71"
 async-trait = "0.1.68"
 llm-chain-llama-sys = { path = "../llm-chain-llama-sys", version = "0.12" }
 llm-chain = { path = "../llm-chain", version = "0.12.2" }
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { version = "1.0.164", features = ["derive"] }
 thiserror = "1.0.40"
 lazy_static = "1.4.0"
 tokio = "1.28.2"

--- a/crates/llm-chain-llama/Cargo.toml
+++ b/crates/llm-chain-llama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-chain-llama"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "A library implementing `llm-chains` for LLamA. Chains can be use to apply the model series to complete complex tasks, such as agents."
 license = "MIT"
@@ -17,7 +17,7 @@ repository = "https://github.com/sobelio/llm-chain/"
 anyhow = "1.0.71"
 async-trait = "0.1.68"
 llm-chain-llama-sys = { path = "../llm-chain-llama-sys", version = "0.12" }
-llm-chain = { path = "../llm-chain", version = "0.12.2" }
+llm-chain = { path = "../llm-chain", version = "0.12.3" }
 serde = { version = "1.0.164", features = ["derive"] }
 thiserror = "1.0.40"
 lazy_static = "1.4.0"

--- a/crates/llm-chain-local/Cargo.toml
+++ b/crates/llm-chain-local/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.4.0"
 llm = "0.1.1"
 llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
 rand = "0.8.5"
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { version = "1.0.164", features = ["derive"] }
 thiserror = "1.0.40"
 
 [dev-dependencies]

--- a/crates/llm-chain-local/Cargo.toml
+++ b/crates/llm-chain-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-chain-local"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "Use `llm-chain` with a local [`llm`](https://github.com/rustformers/llm) backend."
 license = "MIT"
@@ -15,7 +15,7 @@ repository = "https://github.com/sobelio/llm-chain/"
 async-trait = "0.1.68"
 lazy_static = "1.4.0"
 llm = "0.1.1"
-llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
+llm-chain = { path = "../llm-chain", version = "0.12.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0.164", features = ["derive"] }
 thiserror = "1.0.40"

--- a/crates/llm-chain-local/src/executor.rs
+++ b/crates/llm-chain-local/src/executor.rs
@@ -55,6 +55,7 @@ impl llm_chain::traits::Executor for Executor {
     fn new_with_options(options: Options) -> Result<Self, ExecutorCreationError> {
         let opts_from_env = options_from_env().unwrap();
         let opts_cas = OptionsCascade::new()
+            .with_options(&DEFAULT_OPTIONS)
             .with_options(&opts_from_env)
             .with_options(&options);
 

--- a/crates/llm-chain-macros/Cargo.toml
+++ b/crates/llm-chain-macros/Cargo.toml
@@ -3,6 +3,12 @@ name = "llm-chain-macros"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+description = "Set of macros for use with llm-chain"
+keywords = ["llm", "langchain", "ggml", "chain"]
+categories = ["science"]
+authors = ["William Rudenmalm <william@sobel.io>"]
+repository = "https://github.com/sobelio/llm-chain/"
+
 
 [lib]
 proc-macro = true

--- a/crates/llm-chain-macros/Cargo.toml
+++ b/crates/llm-chain-macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "llm-chain-macros"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 proc-macro = true

--- a/crates/llm-chain-macros/Cargo.toml
+++ b/crates/llm-chain-macros/Cargo.toml
@@ -3,6 +3,9 @@ name = "llm-chain-macros"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+proc-macro = true
+
 
 [dependencies]
+syn = "2.0.18"

--- a/crates/llm-chain-macros/Cargo.toml
+++ b/crates/llm-chain-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-chain-macros"
-version = "0.1.0"
+version = "0.12.3"
 edition = "2021"
 license = "MIT"
 description = "Set of macros for use with llm-chain"

--- a/crates/llm-chain-macros/Cargo.toml
+++ b/crates/llm-chain-macros/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "llm-chain-macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/llm-chain-macros/src/lib.rs
+++ b/crates/llm-chain-macros/src/lib.rs
@@ -1,0 +1,83 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use syn::{
+     parse_macro_input, DeriveInput,     __private::{quote::quote,  TokenStream2},
+    Ident, LitStr,
+};
+
+fn literal_from_ident(ident: Ident) -> LitStr {
+    let value = ident.to_string();
+    let span = ident.span();
+    LitStr::new(&value, span)
+}
+
+#[proc_macro_derive(Describe, attributes(purpose))]
+pub fn derive_describe(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let syn::Data::Struct(described_struct) = input.data else {
+        panic!("Can only describe structs")
+    };
+
+    // Parse field attrs
+    let pairs: Vec<(LitStr, LitStr)> = described_struct
+        .fields
+        .iter()
+        .map(|field| {
+            let ident = field
+                .ident
+                .clone()
+                .expect("All struct fields must be named");
+            (
+                literal_from_ident(ident),
+                field
+                    .attrs
+                    .iter()
+                    .filter(|attr| {
+                        attr.path().segments.len() == 1
+                            && attr.path().segments[0].ident == "purpose"
+                    })
+                    .nth(0)
+                    .expect("All fields on the string must have a purpose annotation")
+                    .parse_args::<LitStr>()
+                    .expect("Purpose must be a single string literal"),
+            )
+        })
+        .collect();
+    if pairs.len() == 0 {
+        panic!("You need to annotate each field");
+    }
+
+    // Generate FormatParts from fields
+    let mut format_parts = Vec::new();
+    for (key, purpose) in pairs.into_iter() {
+        let gen: TokenStream2 = quote! {
+            FormatPart {
+                key: #key.to_string(),
+                purpose: #purpose.to_string()
+            }
+        }
+        .into();
+
+        format_parts.push(gen);
+    }
+
+    // Implement trait using generated FormatParts
+    let name = &input.ident;
+
+    let gen: TokenStream = quote! (
+        impl Describe for #name {
+            fn describe() -> Format {
+                 Format {
+                    parts: vec![
+                        #(#format_parts),*
+                    ]
+                }
+            }
+        }
+    )
+    .into();
+
+    gen
+}
+

--- a/crates/llm-chain-macros/src/lib.rs
+++ b/crates/llm-chain-macros/src/lib.rs
@@ -2,8 +2,8 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use syn::{
-     parse_macro_input, DeriveInput,     __private::{quote::quote,  TokenStream2},
-    Ident, LitStr,
+    parse_macro_input, DeriveInput, Ident, LitStr,
+    __private::{quote::quote, TokenStream2},
 };
 
 fn literal_from_ident(ident: Ident) -> LitStr {
@@ -80,4 +80,3 @@ pub fn derive_describe(input: TokenStream) -> TokenStream {
 
     gen
 }
-

--- a/crates/llm-chain-macros/src/main.rs
+++ b/crates/llm-chain-macros/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crates/llm-chain-macros/src/main.rs
+++ b/crates/llm-chain-macros/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/crates/llm-chain-openai/Cargo.toml
+++ b/crates/llm-chain-openai/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3.28"
 async-openai = "0.10.3"
 async-trait = "0.1.68"
 llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
-serde = { version = "1.0.163" }
+serde = { version = "1.0.164" }
 strum = "0.25"
 strum_macros = "0.24"
 thiserror = "1.0.40"

--- a/crates/llm-chain-openai/Cargo.toml
+++ b/crates/llm-chain-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-chain-openai"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "A library implementing `llm-chains` for OpenAI's models. Chains can be use to apply the model series to complete complex tasks, such as text summation."
 license = "MIT"
@@ -16,7 +16,7 @@ repository = "https://github.com/sobelio/llm-chain/"
 futures = "0.3.28"
 async-openai = "0.10.3"
 async-trait = "0.1.68"
-llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
+llm-chain = { path = "../llm-chain", version = "0.12.3", default-features = false }
 serde = { version = "1.0.164" }
 strum = "0.25"
 strum_macros = "0.24"

--- a/crates/llm-chain-openai/Cargo.toml
+++ b/crates/llm-chain-openai/Cargo.toml
@@ -18,7 +18,7 @@ async-openai = "0.10.3"
 async-trait = "0.1.68"
 llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
 serde = { version = "1.0.163" }
-strum = "0.24"
+strum = "0.25"
 strum_macros = "0.24"
 thiserror = "1.0.40"
 tiktoken-rs = { version = "0.4.2", features = ["async-openai"] }

--- a/crates/llm-chain-openai/Cargo.toml
+++ b/crates/llm-chain-openai/Cargo.toml
@@ -25,9 +25,12 @@ tiktoken-rs = { version = "0.4.2", features = ["async-openai"] }
 tokio = "1.28.2"
 
 [dev-dependencies]
-tokio = "1.28.2"
+tokio = { version = "1.28.2", features = ["full"] }
 qdrant-client = "1.2.0"
 llm-chain = { path = "../llm-chain" }
+llm-chain-openai = { path = "../llm-chain-openai" }
+llm-chain-hnsw = { path = "../llm-chain-hnsw" }
+llm-chain-macros = { path = "../llm-chain-macros" }
 anyhow = "1.0.70"
 serde_yaml = "0.9.21"
 

--- a/crates/llm-chain-openai/examples/easy_tools.rs
+++ b/crates/llm-chain-openai/examples/easy_tools.rs
@@ -1,0 +1,219 @@
+use std::{
+    collections::HashMap, convert::Infallible, future::Future, marker::PhantomData, pin::Pin, sync::{Arc},
+};
+
+use async_trait::async_trait;
+use llm_chain::{
+    document_stores::in_memory_document_store::InMemoryDocumentStore, traits::VectorStore, schema::{EmptyMetadata, Document}, tools::{Format, Describe, FormatPart, Yaml, State, Tool, Handler, Pipe},
+};
+
+use llm_chain_hnsw::{HnswVectorStore, HnswArgs};
+use llm_chain_macros::Describe;
+use llm_chain_openai::embeddings::Embeddings;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+
+/// ======================================== USER CODE
+#[derive(Serialize, Deserialize, Describe)]
+struct MyStruct {
+    #[purpose("Unique struct identifier")]
+    id: u32,
+    #[purpose("Name of the struct")]
+    name: String,
+}
+
+impl ToString for MyStruct {
+    fn to_string(&self) -> String {
+        match serde_yaml::to_string(self) {
+            Ok(val) => val,
+            Err(err) => err.to_string(),
+        }
+    }
+}
+
+
+async fn print_yaml(
+    State(MyComplicatedState { num, .. }): State<MyComplicatedState>,
+    Yaml(MyStruct { id, name }): Yaml<MyStruct>,
+) -> Yaml<MyStruct> {
+    let text: String = MyStruct::describe()
+        .parts
+        .iter()
+        .map(|FormatPart { key, purpose }| format!("key: {key} purpose: {purpose}"))
+        .collect();
+    println!("FORMAT: {text}");
+    println!("State: {num}");
+    Yaml(MyStruct { id, name })
+}
+
+/// SIMPLE EXAMPLE OF A TOOL
+struct MyTool {
+    id: u32,
+    name: String,
+    data: Vec<u8>,
+}
+
+#[async_trait]
+impl Tool for MyTool {
+    async fn call(&self, message: String) -> String {
+        format!(
+            "Hello from my tool, LLM! You've asked me to {}. I've got {}, {}, and {:?}",
+            message, self.id, self.name, self.data
+        )
+    }
+}
+
+/// TOOL THAT HAS TO BE PIPED TO HANDLE ERRORS
+#[derive(Debug)]
+struct MyError(pub String);
+
+async fn failable_tool(
+    State(MyComplicatedState { num, .. }): State<MyComplicatedState>,
+    Yaml(MyStruct { id, name }): Yaml<MyStruct>,
+) -> Result<String, MyError> {
+    println!("State: {num}");
+    if id > 18 {
+        Ok(name)
+    } else {
+        Err(MyError("ID was not above 18".into()))
+    }
+}
+
+async fn my_error_handler(res: Result<String, MyError>) -> MyStruct {
+    match res {
+        Ok(val) => MyStruct { id: 19, name: val },
+        Err(MyError(err_msg)) => MyStruct {
+            id: 0,
+            name: format!("Bad luck: {err_msg}"),
+        },
+    }
+}
+
+async fn tool_that_uses_different_state(State(num): State<f64>, Yaml(input): Yaml<MyStruct>) -> MyStruct {
+    println!("Different state: {num}");
+    input
+}
+
+/// USING VECTORSTORES WITH THE NEW TOOLS
+async fn vectorstore_tool(
+    State(MyComplicatedState {
+        hnsw_vector_store, ..
+    }): State<MyComplicatedState>,
+    Yaml(MySimilaritySearchInput { query }): Yaml<MySimilaritySearchInput>,
+) -> MySimilaritySearchOutput {
+    match hnsw_vector_store.similarity_search(query, 1).await {
+        Ok(docs) if docs.len() == 1 => MySimilaritySearchOutput {
+            most_similar_text: docs[0].page_content.clone(),
+            optional_error: None,
+        },
+        Ok(docs) if docs.len() > 1 => MySimilaritySearchOutput { most_similar_text: "".into(), optional_error: Some(MyError("Query executed correctly but more than one document was returned".into())) },
+        Ok(docs) => MySimilaritySearchOutput { most_similar_text: "".into(), optional_error: Some(MyError("Query executed correctly but no documents were found".into())) },
+        Err(err) => MySimilaritySearchOutput {
+            most_similar_text: "".into(),
+            optional_error: Some(MyError(err.to_string())),
+        },
+    }
+}
+
+#[derive(Clone)]
+struct MyComplicatedState {
+    num: u32,
+    hnsw_vector_store: Arc<HnswVectorStore<Embeddings, InMemoryDocumentStore<()>, ()>>,
+}
+
+#[derive(Describe, Deserialize)]
+struct MySimilaritySearchInput {
+    #[purpose("Text which you search for in the vectorstore")]
+    query: String,
+    // Notice that the model no longer has to specify the limit - we can hardcode it in the function
+}
+
+/// ERROR DESCRIPTION WILL GET NICER AS SOON AS WE HAVE A DERIVE Describe FOR ENUMS;
+/// THERE WILL BE A BLANKET IMPL FOR Result<> AND Option<>
+#[derive(Describe)]
+struct MySimilaritySearchOutput {
+    #[purpose("Text that is most similar to the one you searched for")]
+    most_similar_text: String,
+    #[purpose("This will be empty if there was no error")]
+    optional_error: Option<MyError>,
+}
+
+impl ToString for MySimilaritySearchOutput {
+    fn to_string(&self) -> String {
+        if let Some(ref err_msg) = self.optional_error {
+            format!("There was an error with the vectorstore: {err_msg:#?}")
+        } else {
+            self.most_similar_text.clone()
+        }
+    }
+}
+
+fn example_documents() -> Vec<Document<()>> {
+    let doc_dog_definition = r#"The dog (Canis familiaris[4][5] or Canis lupus familiaris[5]) is a domesticated descendant of the wolf. Also called the domestic dog, it is derived from the extinct Pleistocene wolf,[6][7] and the modern wolf is the dog's nearest living relative.[8] Dogs were the first species to be domesticated[9][8] by hunter-gatherers over 15,000 years ago[7] before the development of agriculture.[1] Due to their long association with humans, dogs have expanded to a large number of domestic individuals[10] and gained the ability to thrive on a starch-rich diet that would be inadequate for other canids.[11]
+
+    The dog has been selectively bred over millennia for various behaviors, sensory capabilities, and physical attributes.[12] Dog breeds vary widely in shape, size, and color. They perform many roles for humans, such as hunting, herding, pulling loads, protection, assisting police and the military, companionship, therapy, and aiding disabled people. Over the millennia, dogs became uniquely adapted to human behavior, and the human–canine bond has been a topic of frequent study.[13] This influence on human society has given them the sobriquet of "man's best friend"."#.to_string();
+
+    let doc_woodstock_sound = r#"Sound for the concert was engineered by sound engineer Bill Hanley. "It worked very well", he says of the event. "I built special speaker columns on the hills and had 16 loudspeaker arrays in a square platform going up to the hill on 70-foot [21 m] towers. We set it up for 150,000 to 200,000 people. Of course, 500,000 showed up."[48] ALTEC designed marine plywood cabinets that weighed half a ton apiece and stood 6 feet (1.8 m) tall, almost 4 feet (1.2 m) deep, and 3 feet (0.91 m) wide. Each of these enclosures carried four 15-inch (380 mm) JBL D140 loudspeakers. The tweeters consisted of 4×2-Cell & 2×10-Cell Altec Horns. Behind the stage were three transformers providing 2,000 amperes of current to power the amplification setup.[49][page needed] For many years this system was collectively referred to as the Woodstock Bins.[50] The live performances were captured on two 8-track Scully recorders in a tractor trailer back stage by Edwin Kramer and Lee Osbourne on 1-inch Scotch recording tape at 15 ips, then mixed at the Record Plant studio in New York.[51]"#.to_string();
+
+    let doc_reddit_creep_shots = r#"A year after the closure of r/jailbait, another subreddit called r/CreepShots drew controversy in the press for hosting sexualized images of women without their knowledge.[34] In the wake of this media attention, u/violentacrez was added to r/CreepShots as a moderator;[35] reports emerged that Gawker reporter Adrian Chen was planning an exposé that would reveal the real-life identity of this user, who moderated dozens of controversial subreddits, as well as a few hundred general-interest communities. Several major subreddits banned links to Gawker in response to the impending exposé, and the account u/violentacrez was deleted.[36][37][38] Moderators defended their decisions to block the site from these sections of Reddit on the basis that the impending report was "doxing" (a term for exposing the identity of a pseudonymous person), and that such exposure threatened the site's structural integrity.[38]"#.to_string();
+
+    
+            vec![
+                doc_dog_definition,
+                doc_woodstock_sound,
+                doc_reddit_creep_shots,
+            ]
+            .into_iter()
+            .map(Document::new)
+            .collect()
+       
+}
+
+#[tokio::main]
+pub async fn main() {
+    let message = "
+            id: 23
+            name: Abc
+    "
+    .to_string();
+
+    println!("OPENAI KEY: {}", std::env::var("OPENAI_API_KEY").unwrap());
+    let embeddings = llm_chain_openai::embeddings::Embeddings::default();
+    let document_store = Arc::new(Mutex::new(InMemoryDocumentStore::<()>::new()));
+    let hnsw_vs = Arc::new(HnswVectorStore::new(HnswArgs::default(), Arc::new(embeddings), document_store));
+    hnsw_vs
+    .add_documents(
+        example_documents(),
+    )
+    .await
+    .unwrap();
+    let my_complicated_state = MyComplicatedState {
+        num: 221,
+        hnsw_vector_store: hnsw_vs,
+    };
+
+    let mut handlers: HashMap<String, Box<dyn Tool>> = HashMap::new();
+
+    handlers.insert("yaml".to_string(), Box::new(print_yaml.with_state(my_complicated_state.clone())));
+    handlers.insert(
+        "pipe".to_string(),
+        Box::new(failable_tool.pipe(my_error_handler).with_state(my_complicated_state.clone())),
+    );
+    handlers.insert(
+        "similarity".to_string(),
+        Box::new(vectorstore_tool.with_state(my_complicated_state.clone())),
+    );
+    handlers.insert("Other state".to_string(), Box::new(tool_that_uses_different_state.with_state(12.5)));
+
+    let res = handlers.get("pipe").unwrap().call(message.clone()).await;
+    println!("Pipe response: {res}");
+
+    let res = handlers.get("yaml").unwrap().call(message).await;
+    println!("Yaml response: {res}");
+
+    let res = handlers.get("similarity").unwrap().call("
+            query: Some controversial topic
+    ".to_string()).await;
+    println!("Similarity response: {res}");
+}

--- a/crates/llm-chain-openai/src/chatgpt/executor.rs
+++ b/crates/llm-chain-openai/src/chatgpt/executor.rs
@@ -110,8 +110,10 @@ impl traits::Executor for Executor {
         let opts_cas = self.cascade(Some(opts));
         let model = self.get_model_from_invocation_options(&opts_cas);
         let messages: Vec<ChatCompletionRequestMessage> = format_chat_messages(prompt.to_chat())?;
-
+        let no_messages: Vec<tiktoken_rs::ChatCompletionRequestMessage> = Vec::new();
         let tokens_used =
+            get_chat_completion_max_tokens(&model, no_messages.as_slice())
+                .map_err(|_| PromptTokensError::NotAvailable)? - 
             get_chat_completion_max_tokens(&model, as_tiktoken_messages(messages).as_slice())
                 .map_err(|_| PromptTokensError::NotAvailable)?;
 

--- a/crates/llm-chain-openai/src/chatgpt/executor.rs
+++ b/crates/llm-chain-openai/src/chatgpt/executor.rs
@@ -111,10 +111,9 @@ impl traits::Executor for Executor {
         let model = self.get_model_from_invocation_options(&opts_cas);
         let messages: Vec<ChatCompletionRequestMessage> = format_chat_messages(prompt.to_chat())?;
         let no_messages: Vec<tiktoken_rs::ChatCompletionRequestMessage> = Vec::new();
-        let tokens_used =
-            get_chat_completion_max_tokens(&model, no_messages.as_slice())
-                .map_err(|_| PromptTokensError::NotAvailable)? - 
-            get_chat_completion_max_tokens(&model, as_tiktoken_messages(messages).as_slice())
+        let tokens_used = get_chat_completion_max_tokens(&model, no_messages.as_slice())
+            .map_err(|_| PromptTokensError::NotAvailable)?
+            - get_chat_completion_max_tokens(&model, as_tiktoken_messages(messages).as_slice())
                 .map_err(|_| PromptTokensError::NotAvailable)?;
 
         Ok(TokenCount::new(

--- a/crates/llm-chain-qdrant/Cargo.toml
+++ b/crates/llm-chain-qdrant/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.68"
 llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
 qdrant-client = "1.2.0"
 serde = "1.0.163"
-serde_json = "1.0.96"
+serde_json = "1.0.99"
 thiserror = "1.0.40"
 uuid = "1.3.3"
 

--- a/crates/llm-chain-qdrant/Cargo.toml
+++ b/crates/llm-chain-qdrant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-chain-qdrant"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "For using Qdrant with llm-chain"
 license = "MIT"
@@ -15,7 +15,7 @@ repository = "https://github.com/sobelio/llm-chain/"
 [dependencies]
 anyhow = "1.0.70"
 async-trait = "0.1.68"
-llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
+llm-chain = { path = "../llm-chain", version = "0.12.3", default-features = false }
 qdrant-client = "1.2.0"
 serde = "1.0.164"
 serde_json = "1.0.99"

--- a/crates/llm-chain-qdrant/Cargo.toml
+++ b/crates/llm-chain-qdrant/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.70"
 async-trait = "0.1.68"
 llm-chain = { path = "../llm-chain", version = "0.12.2", default-features = false }
 qdrant-client = "1.2.0"
-serde = "1.0.163"
+serde = "1.0.164"
 serde_json = "1.0.99"
 thiserror = "1.0.40"
 uuid = "1.3.3"

--- a/crates/llm-chain/Cargo.toml
+++ b/crates/llm-chain/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/sobelio/llm-chain/"
 anyhow = "1.0.71"
 async-trait = "0.1.68"
 futures = "0.3.28"
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { version = "1.0.164", features = ["derive"] }
 serde_yaml = { version = "0.9.21" }
 thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["fs", "io-util", "rt", "macros"] }

--- a/crates/llm-chain/Cargo.toml
+++ b/crates/llm-chain/Cargo.toml
@@ -28,7 +28,7 @@ derive_builder = "0.12.0"
 serde_json = "1.0.99"
 reqwest = { version = "0.11.18", features = ["json"] }
 tokio-stream = "0.1.14"
-strum = "0.24.1"
+strum = "0.25.0"
 strum_macros = "0.24.3"
 paste = "1.0.12"
 

--- a/crates/llm-chain/Cargo.toml
+++ b/crates/llm-chain/Cargo.toml
@@ -34,3 +34,4 @@ paste = "1.0.12"
 
 [dev-dependencies]
 mockall = "0.11.4"
+llm-chain-macros = { path = "../llm-chain-macros" }

--- a/crates/llm-chain/Cargo.toml
+++ b/crates/llm-chain/Cargo.toml
@@ -25,7 +25,7 @@ tera = { version = "1.19.0" }
 lazy_static = "1.4.0"
 uuid = { version = "1.3.3", features = ["v4"] }
 derive_builder = "0.12.0"
-serde_json = "1.0.96"
+serde_json = "1.0.99"
 reqwest = { version = "0.11.18", features = ["json"] }
 tokio-stream = "0.1.14"
 strum = "0.24.1"

--- a/crates/llm-chain/Cargo.toml
+++ b/crates/llm-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-chain"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 description = "A library for running chains of LLMs (such as ChatGPT) in series to complete complex tasks, such as text summation."
 license = "MIT"

--- a/crates/llm-chain/Cargo.toml
+++ b/crates/llm-chain/Cargo.toml
@@ -31,6 +31,7 @@ tokio-stream = "0.1.14"
 strum = "0.25.0"
 strum_macros = "0.24.3"
 paste = "1.0.12"
+erased-serde = "0.3.25"
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/crates/llm-chain/examples/tool_derive_describe.rs
+++ b/crates/llm-chain/examples/tool_derive_describe.rs
@@ -1,0 +1,18 @@
+use llm_chain::tools::Describe;
+use llm_chain_macros::Describe;
+use llm_chain::tools::{Format, FormatPart};
+
+
+
+#[derive(Describe)]
+struct MyToolInput {
+    #[purpose("Person's name")]
+    name: String,
+    #[purpose("Person's age")]
+    age: u8
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    println!("{:#?}", MyToolInput::describe());
+}

--- a/crates/llm-chain/examples/tool_derive_describe.rs
+++ b/crates/llm-chain/examples/tool_derive_describe.rs
@@ -1,15 +1,13 @@
 use llm_chain::tools::Describe;
-use llm_chain_macros::Describe;
 use llm_chain::tools::{Format, FormatPart};
-
-
+use llm_chain_macros::Describe;
 
 #[derive(Describe)]
 struct MyToolInput {
     #[purpose("Person's name")]
     name: String,
     #[purpose("Person's age")]
-    age: u8
+    age: u8,
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/crates/llm-chain/src/agents/mod.rs
+++ b/crates/llm-chain/src/agents/mod.rs
@@ -1,1 +1,0 @@
-pub mod self_ask_with_search;

--- a/crates/llm-chain/src/tools/description.rs
+++ b/crates/llm-chain/src/tools/description.rs
@@ -1,4 +1,8 @@
-use serde::{ser::SerializeMap, Serialize, Serializer};
+use std::{collections::HashMap, marker::PhantomData, any::Any, pin::Pin};
+use erased_serde::Deserializer;
+use async_trait::async_trait;
+use futures::Future;
+use serde::{ser::SerializeMap, Serialize, Serializer, de::DeserializeOwned};
 
 /// Represents a single parameter for a tool.
 #[derive(Clone, Debug)]
@@ -92,3 +96,161 @@ impl ToolDescription {
         }
     }
 }
+
+pub struct NotFoundError;
+
+pub trait Tool<S> {
+    type Future: Future<Output = serde_yaml::Value>;
+    fn call(&self, input: serde_yaml::Value, state: S) -> Self::Future;
+    fn describe_input(&self) -> Format;
+    fn describe_output(&self) -> Format;
+}
+
+pub struct DescribedTool<T, S> where T: Tool<S> {
+    tool: Box<T>,
+    name: String,
+    description: String,
+    _marker: PhantomData<S>
+}
+
+impl<T: Tool<S>, S> DescribedTool<T, S> {
+    pub async fn call(&self, name: &str, input: &serde_yaml::Value) -> serde_yaml::Value {
+        todo!()
+    }
+
+    pub fn description(&self) -> ToolDescription {
+        todo!()
+    }
+}
+
+type BoxedFuture = Box<dyn Future<Output = serde_yaml::Value>>;
+type BoxedTool<S> = Box<dyn Tool<S, Future = BoxedFuture>>;
+
+pub struct Toolbox<S> {
+    tools: HashMap<String, BoxedTool<S>>,
+    state: S,
+}
+
+impl<S> Toolbox<S> {
+    pub fn add_tool<T: Tool<S, Future = BoxedFuture>>(&mut self, name: &str, description: &str, tool: T) -> Option<BoxedTool<S>> {
+        self.tools.insert(name.into(), Box::new(tool))
+    }
+
+    pub fn describe_all_tools(&self) -> Result<serde_yaml::Value, serde_yaml::Error> {
+        todo!()
+    }
+
+    pub async fn call_tool(&self, name: &str, input: &serde_yaml::Value) -> Result<serde_yaml::Value, NotFoundError> {
+        todo!()
+    }
+}
+
+impl<F, Fut, Res, S> Tool<S> for F
+where
+    F: FnOnce() -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = Res> + Send,
+    Res: Serialize + Describe,
+    S: Clone
+{
+    type Future = Pin<Box<dyn Future<Output = serde_yaml::Value> + Send>>;
+
+    fn call(&self, _req: serde_yaml::Value, _state: S) -> Self::Future {
+        Box::pin(async move { serde_yaml::to_value(self().await) })
+    }
+}
+
+
+
+// macro_rules! impl_from_request {
+//     (
+//         [$($ty:ident),*], $last:ident
+//     ) => {
+
+//         // This impl must not be generic over M, otherwise it would conflict with the blanket
+//         // implementation of `FromRequest<S, Mut>` for `T: FromRequestParts<S>`.
+//         #[async_trait]
+//         #[allow(non_snake_case, unused_mut, unused_variables)]
+//         impl<S, $($ty,)* $last> FromRequest<S> for ($($ty,)* $last,)
+//         where
+//             $( $ty: FromRequest<S> + Send, )*
+//             $last: FromRequest<S> + Send,
+//             S: Send + Sync,
+//         {
+//             type Rejection = Response;
+
+//             async fn from_request(req: &serde_yaml::Value, state: &S) -> Result<Self, Self::Rejection> {
+//                 $(
+//                     let $ty = $ty::from_request(req, state).await.map_err(|rejection| rejection.into_response())?;
+//                 )*
+
+//                 let $last = $last::from_request(&req, state).await.map_err(|rejection| rejection.into_response())?;
+
+//                 Ok(($($ty,)* $last,))
+//             }
+//         }
+//     };
+// }
+// macro_rules! impl_handler {
+//     (
+//         [$($ty:ident),*], $last:ident
+//     ) => {
+//         #[allow(non_snake_case, unused_mut)]
+//         impl<F, Fut, S, M, $($ty,)* $last> Handler<(M, $($ty,)* $last,), S> for F
+//         where
+//             F: FnOnce($($ty,)* $last,) -> Fut + Clone + Send,
+//             Fut: Future<Output = Response> + Send,
+//             S: Clone + Send + Sync + 'static,
+//             $( $ty: FromRequest<S, M> + Send, )*
+//             $last: FromRequest<S, M> + Send,
+//         {
+//             type Future = Pin<Box<dyn Future<Output = Response> + Send>>;
+
+//             fn call(self, req: serde_yaml::Value, state: S) -> Self::Future {
+//                 Box::pin(async move {
+//                     let state = &state;
+
+//                     $(
+//                         let $ty = match $ty::from_request(&req, state).await {
+//                             Ok(value) => value,
+//                             Err(rejection) => return rejection.into_response(),
+//                         };
+//                     )*
+
+//                     let $last = match $last::from_request(&req, state).await {
+//                         Ok(value) => value,
+//                         Err(rejection) => return rejection.into_response(),
+//                     };
+
+//                     let res = self($($ty,)* $last,).await;
+
+//                     res.into_response()
+//                 })
+//             }
+//         }
+//     };
+// }
+
+// #[rustfmt::skip]
+// macro_rules! all_the_tuples {
+//     ($name:ident) => {
+//         $name!([], T1);
+//         $name!([T1], T2);
+//         $name!([T1, T2], T3);
+//         $name!([T1, T2, T3], T4);
+//         $name!([T1, T2, T3, T4], T5);
+//         $name!([T1, T2, T3, T4, T5], T6);
+//         $name!([T1, T2, T3, T4, T5, T6], T7);
+//         $name!([T1, T2, T3, T4, T5, T6, T7], T8);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8], T9);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9], T10);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10], T11);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11], T12);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12], T13);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13], T14);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14], T15);
+//         $name!([T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15], T16);
+//     };
+// }
+
+// all_the_tuples!(impl_from_request);
+// all_the_tuples!(impl_handler);

--- a/crates/llm-chain/src/tools/mod.rs
+++ b/crates/llm-chain/src/tools/mod.rs
@@ -32,11 +32,11 @@ mod collection;
 mod description;
 #[cfg(feature = "multitool_default")]
 pub mod multitool_default;
-pub use description::{Describe, Format, FormatPart, ToolDescription};
+pub use description::{Describe, Format, FormatPart, ToolDescription, Tool, State, Yaml, FromContext, Handler, Pipe, PipedFn, HandlerService };
 pub mod multitool;
 mod tool;
 #[allow(clippy::module_inception)]
 pub mod tools;
 
 pub use collection::{ToolCollection, ToolInvocationInput, ToolUseError};
-pub use tool::{Tool, ToolError};
+pub use tool::{ToolError};

--- a/crates/llm-chain/src/tools/tools/mod.rs
+++ b/crates/llm-chain/src/tools/tools/mod.rs
@@ -2,14 +2,9 @@
 //!
 
 mod bash;
-mod bing_search;
 mod exit;
 mod python;
-mod vectorstore;
 pub use bash::{BashTool, BashToolError, BashToolInput, BashToolOutput};
-pub use bing_search::{BingSearch, BingSearchError, BingSearchInput, BingSearchOutput};
 pub use exit::{ExitTool, ExitToolError, ExitToolInput, ExitToolOutput};
 pub use python::{PythonTool, PythonToolError, PythonToolInput, PythonToolOutput};
-pub use vectorstore::{
-    VectorStoreTool, VectorStoreToolError, VectorStoreToolInput, VectorStoreToolOutput,
-};
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.12.19] 2023-06-06
+## [0.12.3] 2023-06-27
+
+### Added
+
+- Macro for deriving tools
+- add CUDA support for llm-chain-llama
+
+### Changed
+
+- Bugfix for tiktoken not counting tokens properly
+- Bugfix for defualt options not set in llm-chain-local
+
+## [0.12.2] 2023-06-06
 
 ### Changed
 


### PR DESCRIPTION
Changes to Tools that should make it simpler to define ad-hoc functions for the LLMs to use. Complete with strongly-typed error handling.

This should simplify writing Agents, as they usually have their own tool calling convention, that is different form the yaml Tool calls we used previously.

This PR should also allow to easily include a Toolbox/Tool for each Step in a Chain